### PR TITLE
Add ensure-system-package hook to example

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,10 @@ You will need to have the GitHub [[https://cli.github.com][command line tools]] 
 Here is an example ~use-package~ declaration (though it won't work until I stick this on MELPA):
 
 #+begin_src emacs-lisp
+  (use-package use-package-ensure-system-package
+    :ensure t)
   (use-package codespaces
+    :ensure-system-package gh
     :config
     (codespaces-setup)
     :bind


### PR DESCRIPTION
use-package contains a hook for automatically checking for a system package, and installing it using the system's default package manager if it can't find it in PATH.

See https://github.com/jwiegley/use-package/tree/e5f64cc6d9d0df3721b319eeecca1f4f49ea86a3#use-package-ensure-system-package