### PR TITLE
Customize the default directory

### DIFF
--- a/codespaces.el
+++ b/codespaces.el
@@ -99,7 +99,7 @@ When this is nil, the default of '/workspaces/<repo-name>' is used."
     (if (string-empty-p name) (codespaces-space-name cs) name)))
 
 (defun codespaces-space-repository-name (cs)
-  "Return the repository part of the codespace repo, or if empty, its name."
+  "Return the repository part of the CS codespace repo, or if empty, its name."
   (cl-check-type cs codespaces-space)
   (car (cdr (split-string (codespaces-space-repository cs) "/"))))
 

--- a/codespaces.el
+++ b/codespaces.el
@@ -37,15 +37,17 @@
 (require 'tramp)
 
 (defgroup codespaces nil
-  "Codespaces configuration"
+  "Codespaces configuration."
+  :group 'tramp
   :prefix "codespaces-")
 
 (defcustom codespaces-default-directory nil
   "The default directory for a codespace.
 
-This will be resolved relative to the connection root. By default, this will
-use the default directory for the codespace (the same as if you ran `gh cs ssh`)
-but if you provide a path, relative or absolute, that will be substituted instead.
+This will be resolved relative to the connection root.  By default, this will
+use the default directory for the codespace (the same as if you ran
+`gh cs ssh`) but if you provide a path, relative or absolute, that will be
+substituted instead.
 
 When this is nil, the default of '/workspaces/<repo-name>' is used."
   :group 'codespaces

--- a/codespaces.el
+++ b/codespaces.el
@@ -36,6 +36,21 @@
 
 (require 'tramp)
 
+(defgroup codespaces nil
+  "Codespaces configuration"
+  :prefix "codespaces-")
+
+(defcustom codespaces-default-directory nil
+  "The default directory for a codespace.
+
+This will be resolved relative to the connection root. By default, this will
+use the default directory for the codespace (the same as if you ran `gh cs ssh`)
+but if you provide a path, relative or absolute, that will be substituted instead.
+
+When this is nil, the default of '/workspaces/<repo-name>' is used."
+  :group 'codespaces
+  :type 'string)
+
 (defun codespaces-setup ()
   "Set up the ghcs tramp-method.  Should be called after requiring this package."
   (interactive)
@@ -80,6 +95,11 @@
   (cl-check-type cs codespaces-space)
   (let ((name (codespaces-space-display-name cs)))
     (if (string-empty-p name) (codespaces-space-name cs) name)))
+
+(defun codespaces-space-repository-name (cs)
+  "Return the repository part of the codespace repo, or if emtpy, its name."
+  (cl-check-type cs codespaces-space)
+  (car (cdr (split-string (codespaces-space-repository cs) "/"))))
 
 (defun codespaces-space-describe (cs)
   "Format details about codespace CS for display as marginalia."
@@ -172,7 +192,10 @@
     (unless (codespaces-space-available-p selected)
       (message "Activating codespace (this may take some time)...")
       (codespaces--send-start-sync selected))
-    (find-file (format "/ghcs:%s:/workspaces" (codespaces-space-name selected)))))
+    (find-file (format "/ghcs:%s:%s"
+                       (codespaces-space-name selected)
+                       (or codespaces-default-directory
+                           (format "/workspaces/%s" (codespaces-space-repository-name selected)))))))
 
 (provide 'codespaces)
 

--- a/codespaces.el
+++ b/codespaces.el
@@ -97,7 +97,7 @@ When this is nil, the default of '/workspaces/<repo-name>' is used."
     (if (string-empty-p name) (codespaces-space-name cs) name)))
 
 (defun codespaces-space-repository-name (cs)
-  "Return the repository part of the codespace repo, or if emtpy, its name."
+  "Return the repository part of the codespace repo, or if empty, its name."
   (cl-check-type cs codespaces-space)
   (car (cdr (split-string (codespaces-space-repository cs) "/"))))
 


### PR DESCRIPTION
This defaults to `/workspaces/<repo-name>` (note: **not** `/workspaces/` which had been the default previously!) which is the checked out root of the codespaces' repository (and is typically found in
`/workspaces/<repo-name>/`)