### PR TITLE
ci: fail on emacs check warnings

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,3 +24,4 @@ jobs:
     - uses: leotaku/elisp-check@master
       with:
         file: codespaces.el
+        warnings_as_errors: true


### PR DESCRIPTION
What it says on the tin; if this is a standard PRs should be held to, then CI should fail when it hits a warning.