### PR TITLE
docs: Update TRAMP config recommendations

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,7 +60,7 @@ Use SSH connection sharing to reduce the number of new SSH connections that TRAM
 
 #+begin_src
   ControlMaster auto
-  ControlPath ~/.ssh/sockets/%r@%h
+  ControlPath ~/.ssh/sockets/%C
   ControlPersist 10m
 #+end_src
 

--- a/README.org
+++ b/README.org
@@ -56,18 +56,18 @@ Use the host's PATH as TRAMP's [[https://www.gnu.org/software/emacs/manual/html_
   (add-to-list 'tramp-remote-path 'tramp-own-remote-path)
 #+end_src
 
-Use SSH connection sharing to reduce the number of new SSH connections that TRAMP needs to spawn for refreshing buffers. In your ~~/.ssh/config~ file, add the lines:
+Use SSH connection sharing to reduce the number of new SSH connections that TRAMP needs to spawn for refreshing buffers. In your =~/.ssh/config= file, add the lines:
 
 #+begin_src
-  	ControlMaster auto
-	  ControlPath ~/.ssh/sockets/%r@%h-%p
-	  ControlPersist 600
+  ControlMaster auto
+  ControlPath ~/.ssh/sockets/%C
+  ControlPersist 10m
 #+end_src
 
 And to disable TRAMP's default ControlMaster settings in your Emacs config, add:
 
 #+begin_src emacs-lisp
-  (setq tramp-ssh-controlmaster-options "")
+  (setq tramp-ssh-controlmaster-options nil)
 #+end_src
 
 * User-facing commands

--- a/README.org
+++ b/README.org
@@ -60,7 +60,7 @@ Use SSH connection sharing to reduce the number of new SSH connections that TRAM
 
 #+begin_src
   ControlMaster auto
-  ControlPath ~/.ssh/sockets/%C
+  ControlPath ~/.ssh/sockets/%r@%h
   ControlPersist 10m
 #+end_src
 


### PR DESCRIPTION
- Use `%C` token for `ControlPath` in case `user@host:port` is too long for ssh - see https://github.com/ansible/ansible/issues/11536#issuecomment-153030743 and https://en.wikibooks.org/wiki/OpenSSH/Cookbook/Multiplexing#Multiplexing_Options
- Fix code block and styling.
- Use `nil` rather than empty string for disabling `tramp-use-ssh-controlmaster-options`.
- Slightly more human-readable `ControlPersist`